### PR TITLE
Fix grouper helper for Python 3

### DIFF
--- a/code/inference/Object_Detection_Tracking/utils.py
+++ b/code/inference/Object_Detection_Tracking/utils.py
@@ -39,15 +39,18 @@ class Summary():
     with open(path, "w") as f:
       f.writelines("%s" % ("\n".join(self.lines)))
 
-"""
 def grouper(l, n, fillvalue=None):
-  # given a list and n(batch_size), devide list into n sized chunks
-  # last one will fill None
-  args = [iter(l)]*n
-  out = izip_longest(*args, fillvalue=fillvalue)
-  out = list(out)
-  return out
-"""
+  """Group ``l`` into chunks of length ``n``.
+
+  Missing values are filled with ``fillvalue``. Compatible with both
+  Python 2 and 3.
+  """
+  args = [iter(l)] * n
+  if sys.version_info > (3, 0):
+    out = itertools.zip_longest(*args, fillvalue=fillvalue)
+  else:
+    out = itertools.izip_longest(*args, fillvalue=fillvalue)
+  return list(out)
 # simple FIFO class for moving average computation
 class FIFO_ME:
   def __init__(self, N):

--- a/code/pred_utils.py
+++ b/code/pred_utils.py
@@ -663,10 +663,16 @@ class Dataset(object):
 
 
 def grouper(lst, num):
-  args = [iter(lst)]*num
-  out = itertools.izip_longest(*args, fillvalue=None)
-  out = list(out)
-  return out
+  """Split ``lst`` into chunks of length ``num``.
+
+  Works on both Python 2 and 3.
+  """
+  args = [iter(lst)] * num
+  if sys.version_info > (3, 0):
+    out = itertools.zip_longest(*args, fillvalue=None)
+  else:
+    out = itertools.izip_longest(*args, fillvalue=None)
+  return list(out)
 
 
 def compute_ap(lists):


### PR DESCRIPTION
## Summary
- enable grouper utility for Object_Detection_Tracking
- make grouper in pred_utils and detection utils Python3 compatible

## Testing
- `python -m py_compile code/pred_utils.py code/inference/inf_utils.py code/inference/Object_Detection_Tracking/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68401a28ac788332b2943b0bbfaeec41