### PR TITLE
Fix typo, bug, docs, and add tests

### DIFF
--- a/code/inference/My_main.py
+++ b/code/inference/My_main.py
@@ -118,7 +118,7 @@ parser.add_argument("--inter_person_appearance_path",
                     help="Under output_path, folder name for "
                     "person appearance feature per video per frame per person.")
 parser.add_argument("--inter_scene_seg_path", default="scene_seg",
-                    help="Under output_path, folder name for scen")
+                      help="Under output_path, folder name for scene segmentation results."
 parser.add_argument("--inter_future_pred_path", default="future_pred",
                     help="Under output_path, folder name for "
                          "future prediction results.")
@@ -129,7 +129,7 @@ parser.add_argument("--gpuid", default=0, type=int,
 
 # 5. hyper-parameters
 
-# 5.1 Resize the videos to this HxW, note all intermedia output will be in this
+# 5.1 Resize the videos to this HxW, note all intermediate output will be in this
 # scale.
 parser.add_argument("--max_size", default=1920, type=int,
                     help="resize the video frames to..")

--- a/code/inference/Object_Detection_Tracking/test_gpu.py
+++ b/code/inference/Object_Detection_Tracking/test_gpu.py
@@ -1,3 +1,12 @@
-import tensorflow as tf
-if tf.test.gpu_device_name():
-    print('Default GPU Device: {}'.format(tf.test.gpu_device_name()))
+import pytest
+
+try:
+    import tensorflow as tf
+except ImportError:  # pragma: no cover - optional dependency
+    tf = None
+
+
+def test_gpu_available():
+    if tf is None or not tf.test.is_built_with_cuda():
+        pytest.skip("TensorFlow GPU not available")
+    assert tf.test.gpu_device_name()

--- a/code/inference/inf_utils.py
+++ b/code/inference/inf_utils.py
@@ -343,10 +343,10 @@ def load_obj_boxes(json_file, topk, object2id):
 
 
 def get_nearest(frame_idxs, frame_idx):
-  """Since we don"t run scene seg on every frame,we want to find the nearest."""
+  """Since we don"t run scene seg on every frame, we want to find the nearest."""
   frame_idxs = np.array(frame_idxs)
-  cloests_i = (np.abs(frame_idxs - frame_idx)).argmin()
-  return frame_idxs[cloests_i]
+  closest_i = (np.abs(frame_idxs - frame_idx)).argmin()
+  return frame_idxs[closest_i]
 
 
 # ------------------------ for extracting person appearance feature
@@ -396,7 +396,6 @@ def roi_align(featuremap, boxes, output_shape_h, output_shape_w):
 def load_model_weights(model_path, sess, top_scope=None):
   """Load model weights into tf Graph."""
 
-  tf.global_variables_initializer().run()
   allvars = tf.global_variables()
   allvars = [var for var in allvars if "global_step" not in var.name]
   restore_vars = allvars
@@ -408,6 +407,7 @@ def load_model_weights(model_path, sess, top_scope=None):
   if top_scope is not None:
     restore_vars = [var for var in restore_vars
                     if var.name.split(":")[0].split("/")[0] == top_scope]
+  sess.run(tf.variables_initializer(restore_vars))
   saver = tf.train.Saver(restore_vars, max_to_keep=5)
 
   load_from = model_path

--- a/code/inference/main.py
+++ b/code/inference/main.py
@@ -118,7 +118,7 @@ parser.add_argument("--inter_person_appearance_path",
                     help="Under output_path, folder name for "
                     "person appearance feature per video per frame per person.")
 parser.add_argument("--inter_scene_seg_path", default="scene_seg",
-                    help="Under output_path, folder name for scen")
+                    help="Under output_path, folder name for scene segmentation results."
 parser.add_argument("--inter_future_pred_path", default="future_pred",
                     help="Under output_path, folder name for "
                          "future prediction results.")
@@ -129,7 +129,7 @@ parser.add_argument("--gpuid", default=0, type=int,
 
 # 5. hyper-parameters
 
-# 5.1 Resize the videos to this HxW, note all intermedia output will be in this
+# 5.1 Resize the videos to this HxW, note all intermediate output will be in this
 # scale.
 parser.add_argument("--max_size", default=1920, type=int,
                     help="resize the video frames to..")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+import sys
+import types
+import importlib.util
+import os
+import numpy as np
+
+
+def load_inf_utils():
+    dummy = types.ModuleType('dummy')
+    # Basic stubs
+    sys.modules.setdefault('cv2', dummy)
+    sys.modules.setdefault('tensorflow', dummy)
+    PIL = types.ModuleType('PIL')
+    PIL.Image = dummy
+    sys.modules.setdefault('PIL', PIL)
+    # deep_sort and submodules
+    deep_sort = types.ModuleType('deep_sort')
+    nn_matching = types.ModuleType('nn_matching')
+    tracker = types.ModuleType('tracker')
+    tracker.Tracker = object
+    utils = types.ModuleType('utils')
+    utils.create_obj_infos = dummy
+    utils.linear_inter_bbox = dummy
+    utils.filter_short_objs = dummy
+    deep_sort.nn_matching = nn_matching
+    deep_sort.tracker = tracker
+    deep_sort.utils = utils
+    sys.modules.setdefault('deep_sort', deep_sort)
+    sys.modules.setdefault('deep_sort.nn_matching', nn_matching)
+    sys.modules.setdefault('deep_sort.tracker', tracker)
+    sys.modules.setdefault('deep_sort.utils', utils)
+    application_util = types.ModuleType('application_util')
+    application_util.preprocessing = dummy
+    sys.modules.setdefault('application_util', application_util)
+    class_ids = types.ModuleType('class_ids')
+    class_ids.targetClass2id_new_nopo = dummy
+    class_ids.coco_obj_to_actev_obj = dummy
+    sys.modules.setdefault('class_ids', class_ids)
+    nn = types.ModuleType('nn')
+    nn.resnet_fpn_backbone = dummy
+    nn.fpn_model = dummy
+    sys.modules.setdefault('nn', nn)
+    pred_models = types.ModuleType('pred_models')
+    pred_models.Model = dummy
+    sys.modules.setdefault('pred_models', pred_models)
+    pred_utils = types.ModuleType('pred_utils')
+    pred_utils.activity2id = dummy
+    sys.modules.setdefault('pred_utils', pred_utils)
+
+    file_path = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                             'code', 'inference', 'inf_utils.py')
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+
+    selected = []
+    selected.extend(lines[344:349])
+    selected.extend(lines[776:791])
+    namespace = {'np': np}
+    exec(''.join(selected), namespace)
+    return types.SimpleNamespace(**{k: namespace[k] for k in ['get_nearest', 'relative_to_abs']})
+
+
+def test_relative_to_abs():
+    inf_utils = load_inf_utils()
+    rel = np.array([[1, 0], [1, 1], [0, 1]])
+    start = [0, 0]
+    expected = np.array([[1, 0], [2, 1], [2, 2]])
+    out = inf_utils.relative_to_abs(rel, start)
+    np.testing.assert_array_equal(out, expected)
+
+
+def test_get_nearest():
+    inf_utils = load_inf_utils()
+    frames = [0, 10, 20, 30]
+    assert inf_utils.get_nearest(frames, 17) == 20


### PR DESCRIPTION
## Summary
- fix variable name typo in `get_nearest`
- avoid reinitializing variables when loading model weights
- clarify `--inter_scene_seg_path` help message
- fix comment spelling of "intermediate"
- update GPU test to skip if TensorFlow is unavailable
- add unit tests for utility functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68401a28ceb0833297cdb43236e7d3c4